### PR TITLE
remove warning while using simplePool.

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ module.exports = {
             connection[func](sql, params, function(err, rows, fields, numStatements) {
               if (err)
                 return done(err);
-              connection.end();
+              connection.release();
               return done(null, rows, fields, numStatements);
             });
           });


### PR DESCRIPTION
Since connection.end() is deprecated in mysql2, using connection.release() instead of connection.end() to avoid warning.
